### PR TITLE
Add HtmlAttribute for access to dot's <> syntax

### DIFF
--- a/src/Dot/Text.hs
+++ b/src/Dot/Text.hs
@@ -54,6 +54,20 @@ encodeId (Id theId) = case Text.uncons theId of
       <> "\""
   Nothing -> "\"\""
 
+encodeHtmlId :: Id -> Builder
+encodeHtmlId (Id theId) = case Text.uncons theId of
+  Just (c,_) -> if not (c >= '0' && c <= '9') && Text.all (\c -> (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') theId
+    then "<" <> Builder.fromText theId <> ">"
+    else "<"
+      <> Builder.fromText
+         ( Text.replace "\"" "\\\""
+         $ Text.replace "\n" "\\n"
+         $ Text.replace "\\" "\\\\"
+         $ theId
+         )
+      <> ">"
+  Nothing -> "\"\""
+
 encodeNodeId :: NodeId -> Builder
 encodeNodeId (NodeId theId mport) =
   encodeId theId <> maybe mempty encodePort mport
@@ -132,6 +146,7 @@ encodeAttributes [] = " [];\n"
 
 encodeAttribute :: Attribute -> Builder
 encodeAttribute (Attribute attrId valId) = encodeId attrId <> "=" <> encodeId valId
+encodeAttribute (HtmlAttribute attrId valId) = encodeId attrId <> "=" <> encodeHtmlId valId
 
 encodeGraphDirectionality :: Directionality -> Builder
 encodeGraphDirectionality x = case x of

--- a/src/Dot/Types.hs
+++ b/src/Dot/Types.hs
@@ -67,6 +67,7 @@ data AttributeStatement = AttributeStatement Element [Attribute]
   deriving (Show,Read)
 
 data Attribute = Attribute Id Id
+               | HtmlAttribute Id Id
   deriving (Show,Read)
 
 data NodeStatement = NodeStatement NodeId [Attribute]


### PR DESCRIPTION
The <> syntax allows for some neat things like subscripts, superscripts, and tables as part of labels that just aren't possible with plain strings.